### PR TITLE
[New Mod] Sleep Warp (Updated)

### DIFF
--- a/mods/sleep-warp-updated.json
+++ b/mods/sleep-warp-updated.json
@@ -1,0 +1,4 @@
+{
+  "maven": "maven.modrinth:sleep-warp-updated:2.6.0+1.21.4-rc3",
+  "supportContact": "https://github.com/Patbox/SleepWarp/issues"
+}


### PR DESCRIPTION
Not my mod, but as Patbox gave [approval to include his mods as we want,](https://discord.com/channels/507304429255393322/1314988095501766697/1315063480130474126) I figured I'd submit the PR for this one myself. [Sleep Warp](https://modrinth.com/mod/sleep-warp-updated) increases the tick speed to speed up nights instead of fully skipping them. I find this a nicer balance than skipping, especially on multiplayer servers.

Note that this mod depends on [MidnightLib](https://modrinth.com/mod/midnightlib). The test server seems to pick up on that dependency from SleepWarp's Modrinth maven, so I opted not to make a separate file for it. Let me know if that should be changed.