### PR TITLE
Add Aliven't Messager & MidnightLib

### DIFF
--- a/mods/alivent-messenger.json
+++ b/mods/alivent-messenger.json
@@ -1,0 +1,4 @@
+{
+  "maven": "maven.modrinth:alivent-messager:1.3.3+1.21.4",
+  "supportContact": "https://github.com/A11v1r15/Alivent_messenger/issues"
+}

--- a/mods/midnight-lib.json
+++ b/mods/midnight-lib.json
@@ -1,0 +1,4 @@
+{
+  "maven": "maven.modrinth:midnightlib:1.6.6-fabric",
+  "supportContact": "https://github.com/TeamMidnightDust/MidnightLib/issues/"
+}


### PR DESCRIPTION
So, it's just a small utility that allow us to know if a named mob dies and make their drop have a lore. Maybe you want to make their name be the same colour as their spawn egg or activate the species name so we know which mob is a named mob

Aliven't Messager needs MidnightLib