### PR TITLE
Add Ender Christmas Plus

### DIFF
--- a/mods/ender-christmas+.json
+++ b/mods/ender-christmas+.json
@@ -1,0 +1,4 @@
+{
+  "maven": "maven.modrinth:ender-christmas+:1.1+1.21.1",
+  "supportContact": "https://github.com/cassiancc/Ender-Christmas-Plus/issues"
+}


### PR DESCRIPTION
This mod adds a Christmas texture for the Ender Chest. The Christmas texture works the same as vanilla Christmas Chest textures, and will be visible only during Christmas, unless a config option is changed to show Christmas textures every day.

This is a clientside mod, and not required on the server.