### PR TITLE
[New Mod/Third Party] REI and Cloth Config

### DIFF
--- a/mods/cloth-config.json
+++ b/mods/cloth-config.json
@@ -1,0 +1,4 @@
+{
+  "maven": "maven.modrinth:cloth-config:17.0.144+fabric",
+  "supportContact": "https://github.com/shedaniel/ClothConfig/issues"
+}

--- a/mods/rei.json
+++ b/mods/rei.json
@@ -1,0 +1,4 @@
+{
+  "maven": "maven.modrinth:rei:18.0.796+fabric",
+  "supportContact": "https://github.com/shedaniel/RoughlyEnoughItems/issues"
+}


### PR DESCRIPTION
Roughly Enough Items is a mod that needs no introduction. Recipe viewers make it far easier to find recipes in even a lightly modded environment, as the vanilla recipe book is not as mod-friendly. This mod requires Cloth Config API (included in the PR) as well as Architectury API (already installed).

REI is marked as clientside, but has optional serverside capabilities. With the recent changes to recipes, having it on both feels safe.