### PR TITLE
[New Mod] Creeper Confetti Plus

### DIFF
--- a/mods/creeperconfetti+.json
+++ b/mods/creeperconfetti+.json
@@ -1,0 +1,4 @@
+{
+  "maven": "maven.modrinth:creeperconfetti+:1.1.0+1.21.4",
+  "supportContact": "https://github.com/cassiancc/Creeper-Confetti-Plus/issues"
+}


### PR DESCRIPTION
There was interest in a mod that makes Creeper explosions more fun without attempting to rebuild terrain, so I ported Creeper Confetti to 1.21. This mod causes Creepers to explode into confetti (fireworks), which deal damage to players without affecting the landscape.

There's config options to adjust whether or not it will _always_ become confetti, in case we still want to have a chance for block destruction.