### PR TITLE
Only auto-shut down a dedicated server

### DIFF
--- a/test/src/main/java/test/TestEntrypoint.java
+++ b/test/src/main/java/test/TestEntrypoint.java
@@ -1,14 +1,14 @@
 package test;
 
-import net.fabricmc.api.ModInitializer;
+import net.fabricmc.api.DedicatedServerModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import org.spongepowered.asm.mixin.MixinEnvironment;
 
-public class TestEntrypoint implements ModInitializer {
+public class TestEntrypoint implements DedicatedServerModInitializer {
     private int ticks = 0;
 
     @Override
-    public void onInitialize() {
+    public void onInitializeServer() {
         ServerTickEvents.END_SERVER_TICK.register(server -> {
             ticks++;
 

--- a/test/src/main/resources/fabric.mod.json
+++ b/test/src/main/resources/fabric.mod.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "environment": "*",
   "entrypoints": {
-    "main": [
+    "server": [
       "test.TestEntrypoint"
     ]
   }


### PR DESCRIPTION
As haykam pointed out in #8, `runClient` will still automatically shut down a client after 2.5 seconds, as the testmod's auto shut down was in the main initializer. I've moved it to a dedicated server intializer so that `runProductionAutoTestServer` can still be used as before, while also allowing `runClient` to be used to test more complex issues with mod interactions.