### PR TITLE
Add the Phantom Lucidity mod

### DIFF
--- a/mods/phantom-lucidity.json
+++ b/mods/phantom-lucidity.json
@@ -1,0 +1,4 @@
+{
+  "maven": "curse.maven:phantom-lucidity-1161993:6003797",
+  "supportContact": "https://github.com/haykam821/Phantom-Lucidity/issues"
+}


### PR DESCRIPTION
This pull request introduces the [Phantom Lucidity](https://www.curseforge.com/minecraft/mc-mods/phantom-lucidity) mod, which provides a more balanced way for managing phantoms than disabling the `doInsomnia` game rule.