### PR TITLE
Temporarily remove unbreakable.

### DIFF
--- a/mods/unbreakable.json
+++ b/mods/unbreakable.json
@@ -1,4 +1,0 @@
-{
-  "maven": "maven.modrinth:durability-rework:v1.0.3+1.21.4",
-  "supportContact": "https://github.com/sylenthuntress/Unbreakable/issues"
-}


### PR DESCRIPTION
- Mod thinks that you've just broken a tool (and grants you 3x crit+knockback multiplier) when using empty hand during combat. You can easily stack this for an unfair advantage.
- Breaks flight assistant and grind enchantments math because of the negative durability.

