### PR TITLE
Add Extended Drawers

### DIFF
--- a/mods/extended-drawers.json
+++ b/mods/extended-drawers.json
@@ -1,0 +1,4 @@
+{
+  "maven": "maven.modrinth:extended-drawers:4.0.1+mc.1.21.4",
+  "supportContact": "https://github.com/MattiDragon/ExtendedDrawers/issues"
+}


### PR DESCRIPTION
Seems to work fine after a quick test. Some log spam related to shadow drawers and polymer due to polymer assuming that every an `item` nbt tag in block entities follows a specific format, but doesn't seem to affect gameplay.