### PR TITLE
fix: add mixins to FlightAssistant to patch a few bugs

### DIFF
--- a/mod/build.gradle
+++ b/mod/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     mappings "net.fabricmc:yarn:1.21.4+build.1:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:0.111.0+1.21.4"
+    modCompileOnly "maven.modrinth:flightassistant:2.3.4+mc1.21.2"
 }
 
 processResources {

--- a/mod/src/main/java/holiday/server/mixin/ServerListMixin.java
+++ b/mod/src/main/java/holiday/server/mixin/ServerListMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.util.List;
 
 @Mixin(ServerList.class)
-public class ServerListMixin {
+abstract class ServerListMixin {
 	@Shadow
 	@Final
 	private List<ServerInfo> servers;

--- a/mod/src/main/java/holiday/server/mixin/flightassistant/AirDataComputerMixin.java
+++ b/mod/src/main/java/holiday/server/mixin/flightassistant/AirDataComputerMixin.java
@@ -1,0 +1,15 @@
+package holiday.server.mixin.flightassistant;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import ru.octol1ttle.flightassistant.computers.impl.AirDataComputer;
+
+@Mixin(value = AirDataComputer.class, remap = false)
+abstract class AirDataComputerMixin {
+    @Inject(method = "validate(FFF)F", at = @At("HEAD"), cancellable = true)
+    private static void cancelValidate(float f, float min, float max, CallbackInfoReturnable<Float> cir) {
+        cir.setReturnValue(f);
+    }
+}

--- a/mod/src/main/java/holiday/server/mixin/flightassistant/ElytraStateControllerMixin.java
+++ b/mod/src/main/java/holiday/server/mixin/flightassistant/ElytraStateControllerMixin.java
@@ -1,0 +1,20 @@
+package holiday.server.mixin.flightassistant;
+
+import net.fabricmc.fabric.api.util.TriState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import ru.octol1ttle.flightassistant.computers.impl.safety.ElytraStateController;
+
+@Mixin(value = ElytraStateController.class, remap = false)
+abstract class ElytraStateControllerMixin {
+    @Shadow
+    private TriState syncedState;
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void setInitialSyncedState(CallbackInfo ci) {
+        this.syncedState = TriState.DEFAULT;
+    }
+}

--- a/mod/src/main/resources/holiday.mixins.json
+++ b/mod/src/main/resources/holiday.mixins.json
@@ -3,6 +3,8 @@
   "package": "holiday.server.mixin",
   "compatibilityLevel": "JAVA_21",
   "client": [
+    "flightassistant.AirDataComputerMixin",
+    "flightassistant.ElytraStateControllerMixin",
     "ServerListMixin"
   ],
   "injectors": {


### PR DESCRIPTION
This PR is a dependency of #44 

1) `AirDataComputerMixin`: completely removes float number validation. Fixes `ALERT SYS FAULT (ALL ALERTS LOST)` fault and `E/HLTH` flag appearing when Unbreakable reduces durability to negative numbers
2) `ElytraStateControllerMixin`: Fixes an uninitialized-field-access bug that causes `ELYTRA SYS FAULT (PROT LOST)` to appear when the player logs in mid-air