### PR TITLE
Update ClickThrough+

### DIFF
--- a/mods/clickthrough+.json
+++ b/mods/clickthrough+.json
@@ -1,4 +1,4 @@
 {
-  "maven": "maven.modrinth:clickthrough+:3.1+1.21.2",
+  "maven": "maven.modrinth:clickthrough+:3.2+1.21.2",
   "supportContact": "https://github.com/cassiancc/ClickThrough-Plus/issues"
 }


### PR DESCRIPTION
ClickThrough Plus 3.2 fixes compatibility issues with Expanded Storage's chests.